### PR TITLE
Fix jar conflict issue because of ordering

### DIFF
--- a/bin/glue-setup.sh
+++ b/bin/glue-setup.sh
@@ -18,8 +18,8 @@ export PYTHONPATH="$GLUE_PY_FILES:$PYTHONPATH"
 # Run mvn copy-dependencies target to get the Glue dependencies locally
 mvn -f $ROOT_DIR/pom.xml -DoutputDirectory=$ROOT_DIR/jarsv1 dependency:copy-dependencies
 # Remove two jars for jar conflict problems with SPARK_HOME/jars 
-rm ${ROOT_DIR}/jarsv1/netty-3.6.2.Final.jar
-rm ${ROOT_DIR}/jarsv1/netty-all-4.0.23.Final.jar
+rm ${ROOT_DIR}/jarsv1/netty-*.jar
+mv ${ROOT_DIR}/jarsv1/* ${SPARK_HOME}/jars/
 
 export SPARK_CONF_DIR=${ROOT_DIR}/conf
 mkdir $SPARK_CONF_DIR


### PR DESCRIPTION
Fixing the following problem - 

py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: java.lang.SecurityException: class "javax.servlet.FilterRegistration"'s signer information does not match signer information of other classes in the same package
